### PR TITLE
Optimize Order Sync to avoid middle orders

### DIFF
--- a/data_sync_service/check_data.py
+++ b/data_sync_service/check_data.py
@@ -11,7 +11,7 @@ def get_recent_values(es, index_name, time):
             "bool": {
                 "filter": {
                     "range": {
-                        "end_time": {
+                        "epoch_end": {
                             "gt": time
                         }
                     }
@@ -25,11 +25,11 @@ def get_recent_values(es, index_name, time):
 
 es = Elasticsearch(ES_HOST)
 
-print(f'Getting recent values from {time.time() - 300}')
+print(f'Getting recent values from {time.time() - 60*10}')
 
-results = get_recent_values(es, 'data_log', time.time() - 300)
+results = get_recent_values(es, 'data_log', time.time() - 60*10)
 
 if len(results) > 0:
     print(f'Found {len(results)} results')
 else:
-    raise Exception('No new data ingested into Elasticsearch index for the last 5 minutes.')
+    raise Exception('No new data ingested into Elasticsearch index for the last 10 minutes.')


### PR DESCRIPTION
* Reduce orders returned to just top and bottom for an item id at a station.
* Set time out when rate limit is approached
* Update start and end time to be datetime strings
* Add timeout after each run